### PR TITLE
docs: add install instructions and note about `eslint` as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Valid values for the `--concurrency` option are:
 * **`off`**:
   No multithreading, run like ESLint. This is not the same as `--concurrency=1`.
 
-> Normally, a performance improvement **will be only noticeable on systems with 4 or more CPUs.**
+> Normally, a performance improvement **will be only noticeable on systems with 4 or more CPUs**.
 
-## `ESLint` is installed as dependency
+## `ESLint` is installed as a dependency
 
-This package has `ESLint` set as dependency, so if you already have installed it, but with a different version than the one specified in the `package.json` of this package you might have inconsistent results between the CLI and the editor.
+This package has ESLint set as a dependency, so if you already have `eslint` installed, but with a different version than the one specified in the `package.json` of this package you might get inconsistent results between the CLI and the editor.
 
 To check the version of `ESLint` used by this package you can use:
 
@@ -49,7 +49,7 @@ To check the version of `ESLint` used by this package you can use:
 npx eslint-p -v
 ```
 
-To avoid inconsistencies your should install the same `eslint` version used by this package or remove you `eslint` entry from your `package.json`.
+To avoid inconsistencies, install the same `eslint` version used by this package or remove the `eslint` dependency from your `package.json`.
 
 [You can find more information on this PR](https://github.com/origin-1/eslint-p/pull/1).
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A drop-in replacement for ESLint 9 featuring multithreaded parallel linting.
 
-> [!IMPORTANT]
-> Legacy `.eslintrc` configuration is not supported.
+> **IMPORTANT:** Legacy `.eslintrc` configuration is not supported.
 
 ## Installation
 
@@ -38,7 +37,6 @@ Valid values for the `--concurrency` option are:
 * **`off`**:
   No multithreading, run like ESLint. This is not the same as `--concurrency=1`.
 
-> [!NOTE]
 > Normally, a performance improvement **will be only noticeable on systems with 4 or more CPUs.**
 
 ## `ESLint` is installed as dependency
@@ -51,10 +49,9 @@ To check the version of `ESLint` used by this package you can use:
 npx eslint-p -v
 ```
 
-> [!TIP]
-> To avoid inconsistencies your should install the same `eslint` version used by this package or remove you `eslint` entry from your `package.json`.
+To avoid inconsistencies your should install the same `eslint` version used by this package or remove you `eslint` entry from your `package.json`.
 
-[YOu can find more information on this PR](https://github.com/origin-1/eslint-p/pull/1).
+[You can find more information on this PR](https://github.com/origin-1/eslint-p/pull/1).
 
 [npm badge]: https://img.shields.io/npm/v/eslint-p?logo=npm
 [npm URL]: https://www.npmjs.com/package/eslint-p

--- a/README.md
+++ b/README.md
@@ -2,7 +2,22 @@
 
 A drop-in replacement for ESLint 9 featuring multithreaded parallel linting.
 
-**IMPORTANT:** Legacy eslintrc configuration is not supported.
+> [!IMPORTANT]
+> Legacy `.eslintrc` configuration is not supported.
+
+## Installation
+
+```shell
+npm i --save-dev eslint-p
+```
+
+```shell
+yarn add --dev eslint-p
+```
+
+```shell
+pnpm add --save-dev eslint-p
+```
 
 ## Usage
 
@@ -23,7 +38,23 @@ Valid values for the `--concurrency` option are:
 * **`off`**:
   No multithreading, run like ESLint. This is not the same as `--concurrency=1`.
 
-Normally, a performance improvement will be only noticeable on systems with 4 or more CPUs.
+> [!NOTE]
+> Normally, a performance improvement **will be only noticeable on systems with 4 or more CPUs.**
+
+## `ESLint` is installed as dependency
+
+This package has `ESLint` set as dependency, so if you already have installed it, but with a different version than the one specified in the `package.json` of this package you might have inconsistent results between the CLI and the editor.
+
+To check the version of `ESLint` used by this package you can use:
+
+```shell
+npx eslint-p -v
+```
+
+> [!TIP]
+> To avoid inconsistencies your should install the same `eslint` version used by this package or remove you `eslint` entry from your `package.json`.
+
+[YOu can find more information on this PR](https://github.com/origin-1/eslint-p/pull/1).
 
 [npm badge]: https://img.shields.io/npm/v/eslint-p?logo=npm
 [npm URL]: https://www.npmjs.com/package/eslint-p


### PR DESCRIPTION
- Added a section dedicated to `eslint` managed as dependency 
  (Followup to #1)
- Added `Installation` section
- I used [Github Markdown alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) to highlight some already present information